### PR TITLE
fix: check balance after deposit

### DIFF
--- a/contracts/exchange/lib/Errors.sol
+++ b/contracts/exchange/lib/Errors.sol
@@ -48,6 +48,9 @@ library Errors {
     /// @notice Thrown when msg.value is not equal to deposit amount
     error Exchange_InvalidEthAmount();
 
+    /// @notice Thrown when received amount mismatch expected amount
+    error Exchange_DepositWithAuthorization_ReceivedAmountMismatch(uint256 expectedAmount, uint256 receivedAmount);
+
     /// @notice Thrown when insufficient ETH is sent
     error Exchange_InsufficientEth();
 

--- a/test/mock/WETH9.sol
+++ b/test/mock/WETH9.sol
@@ -24,6 +24,10 @@ contract WETH9Mock {
         deposit();
     }
 
+    fallback() external payable {
+        deposit();
+    }
+
     function deposit() public payable {
         balanceOf[msg.sender] += msg.value;
         emit Deposit(msg.sender, msg.value);


### PR DESCRIPTION
- Check the token exchange balance after `depositWithAuthorization` to ensure the exchange has received the correct amount. 
- Revert the transaction if the received amount does not match.
